### PR TITLE
Stay in bounds

### DIFF
--- a/mpe/RL_switch_sides.py
+++ b/mpe/RL_switch_sides.py
@@ -11,7 +11,6 @@ while env.agents:
     # insert policy here
 
     # Prevent agents from leaving environment boundaries
-    masks = {}
     for agent in observations:
         # Agent observations: `[self_vel, self_pos, landmark_rel_positions, other_agent_rel_positions, communication]`
         x_pos, y_pos = observations[agent][2], observations[agent][3]

--- a/mpe/RL_switch_sides.py
+++ b/mpe/RL_switch_sides.py
@@ -1,12 +1,28 @@
 import switch_sides_v0
+import numpy as np
 
+masks = {}
+buffer = 20 #cm
 env = switch_sides_v0.parallel_env(render_mode="human")
 observations, infos = env.reset()
 env.render()
 
 while env.agents:
-    # this is where you would insert your policy
-    actions = {agent: env.action_space(agent).sample() for agent in env.agents}
+    # insert policy here
+
+    # Prevent agents from leaving environment boundaries
+    masks = {}
+    for agent in observations:
+        # Agent observations: `[self_vel, self_pos, landmark_rel_positions, other_agent_rel_positions, communication]`
+        x_pos, y_pos = observations[agent][2], observations[agent][3]
+        masks[agent] = np.array([1,
+                       1 if x_pos > buffer else 0,
+                       1 if x_pos < env.aec_env.length - buffer else 0,
+                       1 if y_pos < env.aec_env.width - buffer else 0,
+                       1 if y_pos > 0 + buffer else 0], dtype=np.int8)
+    
+    # Agent action space: `[no_action, move_left, move_right, move_down, move_up]`
+    actions = {agent: env.action_space(agent).sample(mask=masks[agent]) for agent in env.agents}
 
     observations, rewards, terminations, truncations, infos = env.step(actions)
 env.close()

--- a/mpe/RL_switch_sides.py
+++ b/mpe/RL_switch_sides.py
@@ -14,11 +14,11 @@ while env.agents:
     for agent in observations:
         # Agent observations: `[self_vel, self_pos, landmark_rel_positions, other_agent_rel_positions, communication]`
         x_pos, y_pos = observations[agent][2], observations[agent][3]
-        masks[agent] = np.array([1,
-                       1 if x_pos > buffer else 0,
-                       1 if x_pos < env.aec_env.length - buffer else 0,
-                       1 if y_pos < env.aec_env.width - buffer else 0,
-                       1 if y_pos > 0 + buffer else 0], dtype=np.int8)
+        masks[agent] = np.array([1, # no action
+                       1 if x_pos > buffer else 0, # move left
+                       1 if x_pos < env.aec_env.length - buffer else 0, #move right
+                       1 if y_pos > buffer else 0, # move down
+                       1 if y_pos < env.aec_env.width - buffer else 0], dtype=np.int8) # move up
     
     # Agent action space: `[no_action, move_left, move_right, move_down, move_up]`
     actions = {agent: env.action_space(agent).sample(mask=masks[agent]) for agent in env.agents}

--- a/mpe/switch_sides/simple_env.py
+++ b/mpe/switch_sides/simple_env.py
@@ -308,7 +308,6 @@ class SimpleEnv(AECEnv):
                 radius = entity.radius
                 pygame.draw.circle(self.screen, entity.color * 200, (x, y), radius)
                 pygame.draw.circle(self.screen, (0, 0, 0), (x, y), radius, 1)  # borders
-
                 assert (0 < x < self.length and 0 < y < self.width), f"Coordinates {(x, y)} are out of bounds."
             elif isinstance(entity, Landmark):
                 l, w = entity.length, entity.width

--- a/mpe/switch_sides/simple_env.py
+++ b/mpe/switch_sides/simple_env.py
@@ -295,9 +295,6 @@ class SimpleEnv(AECEnv):
             self.clock.tick(self.metadata["render_fps"])
             return
         
-
-
-
     def draw(self):
         # clear screen
         self.screen.fill((255, 255, 255))
@@ -307,20 +304,16 @@ class SimpleEnv(AECEnv):
         for e, entity in enumerate(self.world.entities):
             # geometry
             x, y = entity.state.p_pos
-            
             if isinstance(entity, Agent):
                 radius = entity.radius
                 pygame.draw.circle(self.screen, entity.color * 200, (x, y), radius)
                 pygame.draw.circle(self.screen, (0, 0, 0), (x, y), radius, 1)  # borders
+
+                assert (0 < x < self.length and 0 < y < self.width), f"Coordinates {(x, y)} are out of bounds."
             elif isinstance(entity, Landmark):
                 l, w = entity.length, entity.width
                 pygame.draw.rect(self.screen, entity.color * 200, (x, y, w, l))
                 pygame.draw.rect(self.screen, (0, 0, 0), (x, y, w, l), 1)
-
-            #TODO: Add this assert back when we limit agents from leaving boundary
-            #assert (
-            #    0 < x < self.width and 0 < y < self.height
-            #), f"Coordinates {(x, y)} are out of bounds."
 
             # text
             if isinstance(entity, Agent):

--- a/mpe/switch_sides/switch_sides.py
+++ b/mpe/switch_sides/switch_sides.py
@@ -66,7 +66,7 @@ class raw_env(SimpleEnv, EzPickle):
         self,
         N=4,
         local_ratio=0.5,
-        max_cycles=25,
+        max_cycles=100,
         continuous_actions=False,
         render_mode=None
     ):


### PR DESCRIPTION
Resolved issue #13. Restrict agent actions so that they can't leave the bounds of the environment. Did this by passing in a mask argument into the sample() method.